### PR TITLE
Fix SearchBar accessibility issue

### DIFF
--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -28,11 +28,12 @@ const SearchBar = ({ fetchWeatherByCity, loading }) => {
         value={city}
         onChange={handleInputChange}
         placeholder="Enter city name"
+        aria-label="City"
         disabled={loading}
       />
       <button type="submit" disabled={loading}>
         {loading ? "Searching..." : "Search"}
-      </button>{" "}
+      </button>
     </form>
   );
 };


### PR DESCRIPTION
## Summary
- enhance accessibility of `SearchBar` input field
- remove stray whitespace fragment in SearchBar button

## Testing
- `npm start --silent` *(fails: error:0308010C:digital envelope routines::unsupported)*
- `npm run build --silent` *(fails: error:0308010C:digital envelope routines::unsupported)*

------
https://chatgpt.com/codex/tasks/task_e_6846d193e078832c8fb09b1f5234f1e6