### PR TITLE
Update to React 18 root API

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,10 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import ReactDOM from 'react-dom/client';
 import App from './App';
 import './styles/App.css';
 
-ReactDOM.render(
+ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>,
-  document.getElementById('root')
+  </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- replace deprecated `ReactDOM.render` with `ReactDOM.createRoot`

## Testing
- `npm test` *(fails: SearchBar tests expect calls that didn't occur)*
- `NODE_OPTIONS=--openssl-legacy-provider npm start`

------
https://chatgpt.com/codex/tasks/task_e_6846d19787e4832cabc5de4138b68cbc