### PR TITLE
Fix SearchBar tests to pass loading prop

### DIFF
--- a/src/components/tests/SearchBar.test.js
+++ b/src/components/tests/SearchBar.test.js
@@ -3,8 +3,10 @@ import { render, fireEvent, screen, waitFor } from "@testing-library/react";
 import SearchBar from "../SearchBar";
 
 // Helper to render SearchBar with a mock fetchWeatherByCity
-const setup = (fetchWeatherByCity = jest.fn()) => {
-  render(<SearchBar fetchWeatherByCity={fetchWeatherByCity} />);
+const setup = (fetchWeatherByCity = jest.fn(), loading = false) => {
+  render(
+    <SearchBar fetchWeatherByCity={fetchWeatherByCity} loading={loading} />
+  );
   const input = screen.getByPlaceholderText(/enter city name/i);
   const button = screen.getByRole("button", { name: /search/i });
   return { input, button, fetchWeatherByCity };


### PR DESCRIPTION
## Summary
- update test helper to provide `loading` prop for SearchBar

## Testing
- `npm test --silent` *(fails: cannot find module 'is-ci')*

------
https://chatgpt.com/codex/tasks/task_e_6846db230afc832c9becce05d6cb4326